### PR TITLE
Scan Jenkins and Hudson plugins

### DIFF
--- a/src/main/java/com/mergebase/log4j/Log4JDetector.java
+++ b/src/main/java/com/mergebase/log4j/Log4JDetector.java
@@ -182,7 +182,9 @@ public class Log4JDetector {
                     || "jar".equalsIgnoreCase(suffix)
                     || "war".equalsIgnoreCase(suffix)
                     || "ear".equalsIgnoreCase(suffix)
-                    || "aar".equalsIgnoreCase(suffix)) {
+                    || "aar".equalsIgnoreCase(suffix)
+                    || "jpi".equalsIgnoreCase(suffix)
+                    || "hpi".equalsIgnoreCase(suffix)) {
                 return 0;
             }
         }


### PR DESCRIPTION
This fixes #54.

I'll have to find a JPI plugin to test against, although I'd imagine it'd be the same.

----

**Before:**

```sh
$ java -jar target/log4j-detector-2021.12.17.jar /tmp/checkmarx.hpi 
-- github.com/mergebase/log4j-detector v2021.12.17 (by mergebase.com) analyzing paths (could take a while).
-- Note: specify the '--verbose' flag to have every file examined printed to STDERR.
-- Skipping /tmp/checkmarx.hpi - Not a zip/jar/war file.
-- No vulnerable Log4J 2.x samples found in supplied paths: [/tmp/checkmarx.hpi]
-- Congratulations, the supplied paths are not vulnerable to CVE-2021-44228 or CVE-2021-45046 !  :-) 
```

**After:**

```sh
$ java -jar target/log4j-detector-2021.12.17.jar /tmp/checkmarx.hpi
-- github.com/mergebase/log4j-detector v2021.12.17 (by mergebase.com) analyzing paths (could take a while).
-- Note: specify the '--verbose' flag to have every file examined printed to STDERR.
/tmp/checkmarx.hpi!/WEB-INF/lib/log4j-core-2.13.3.jar contains Log4J-2.x   >= 2.10.0 _VULNERABLE_
```