### PR TITLE
Canonicalize --exclude paths so that it works in Windows

### DIFF
--- a/src/main/java/com/mergebase/log4j/Log4JDetector.java
+++ b/src/main/java/com/mergebase/log4j/Log4JDetector.java
@@ -101,8 +101,10 @@ public class Log4JDetector {
 
         Iterator<String> it = argsList.iterator();
         List<String> stdinLines = new ArrayList<String>();
+		int argIdx = 0;
         while (it.hasNext()) {
             final String argOrig = it.next().trim();
+			System.out.println("Arg #" + argIdx++ + ": " + argOrig);
             if ("--debug".equals(argOrig)) {
                 debug = true;
                 it.remove();
@@ -122,7 +124,9 @@ public class Log4JDetector {
                         List<Object> list = (List) o;
                         for (Object obj : list) {
                             if (obj != null) {
-                                excludes.add(String.valueOf(obj));
+								
+								String excl_canon = canonicalize(new File(String.valueOf(obj))).getPath();
+                                excludes.add(excl_canon);
                             }
                         }
                     }


### PR DESCRIPTION
1. Canonicalize paths in --exclude array
2. Add para dump, mainly for troubleshooting in Windows (without this I will not be able to come out with the exclude argument below (see https://github.com/mergebase/log4j-detector/issues/62#issuecomment-1005549050):
java -jar log4j-detector-2021.12.20.jar --verbose --exclude="[\"D:\\\\scan\\\\nf\\\\item\\\\ignore\", \"D:\\\\scan\\\\nf\\\\item\\\\ignore2\"]" d:\scan\nf